### PR TITLE
Change icon characters if default encoding is not utf-8

### DIFF
--- a/lib/pyqcheck/arbitrary.py
+++ b/lib/pyqcheck/arbitrary.py
@@ -41,6 +41,18 @@ class Arbitrary(object):
     self.arbitraries = args
     self.test_result = []
 
+    try:
+      encoding = kwargs['_encoding'] if '_encoding' in kwargs else sys.stdout.encoding
+      '\u2602'.encode(encoding)
+    except UnicodeEncodeError:
+      self.ICON_SUCCESS = 'success'
+      self.ICON_FAILURE = 'failure'
+      self.ICON_ERROR = 'error  '
+    else:
+      self.ICON_SUCCESS = '\u2600'
+      self.ICON_FAILURE = '\u2601'
+      self.ICON_ERROR = '\u2603'
+
   def __get_arbitrary_content(self, arbitrary):
     if isinstance(arbitrary, str):
       module_filename = 'pq_' + arbitrary.lower()
@@ -109,7 +121,7 @@ class Arbitrary(object):
 
         success = success + 1 if is_valid else success
         failure = failure + 1 if not is_valid else failure
-        icon = '\u2600' if is_valid else '\u2601'
+        icon = self.ICON_SUCCESS if is_valid else self.ICON_FAILURE
 
         if self.verbose:
           verbose.append(
@@ -120,7 +132,7 @@ class Arbitrary(object):
       except exception as error:
         if self.verbose:
           verbose.append(
-            ('\u2603' + '  ' + 
+            (self.ICON_ERROR + '  ' + 
              func.__name__ + verbose_valiable)
           )
 

--- a/lib/test/test_arbitrary.py
+++ b/lib/test/test_arbitrary.py
@@ -1,0 +1,68 @@
+# -*- coding:utf-8 -*-
+
+from unittest import TestCase
+
+from _import import PyQCheck, Arbitrary
+
+def get_result(property_result, encoding=None):
+  if encoding is None:
+    arb = Arbitrary(
+            'integer',
+            'integer'
+          )
+  else:
+    arb = Arbitrary(
+            'integer',
+            'integer',
+            _encoding=encoding
+          )
+  arb = arb.property('test', lambda x, y: property_result)
+
+  return PyQCheck(verbose=True).add(arb).run(10).results
+
+def setUp(klass):
+  def setUp(self):
+    PyQCheck().clear()
+  klass.setUp = setUp
+  return klass
+
+
+@setUp
+class TestGivenEncodingIsCP932(TestCase):
+  def test_WhenRunArbitrarySuccessfullyThenShowSuccess(self):
+    results = get_result(True, 'cp932')
+   
+    assert len(results) != 0
+    for result in results:
+      assert len(result.verbose) != 0
+      for v in result.verbose:
+        assert v.startswith('success')
+   
+  def test_WhenRunArbitraryWithFailureThenShowFailure(self):
+    results = get_result(False, 'cp932')
+   
+    assert len(results) != 0
+    for result in results:
+      assert len(result.verbose) != 0
+      for v in result.verbose:
+        assert v.startswith('failure')
+
+@setUp
+class TestGivenEncodingIsUTF8(TestCase):
+  def test_WhenRunArbitrarySuccessfullyThenShowCharacter0x2600(self):
+    results = get_result(True)
+   
+    assert len(results) != 0
+    for result in results:
+      assert len(result.verbose) != 0
+      for v in result.verbose:
+        assert v[0] == '\u2600'
+
+  def test_WhenRunArbitraryWithFailureThenShowCharacter0x2601(self):
+    results = get_result(False)
+   
+    assert len(results) != 0
+    for result in results:
+      assert len(result.verbose) != 0
+      for v in result.verbose:
+        assert v[0] == '\u2601'


### PR DESCRIPTION
Using some platforms which don't use utf-8 as default encoding(especially Windows OSs), verbose icons in the QC result won't be shown and it occurs UnicodeEncodeError.
So I would suggest that non utf-8 environments use ascii strings as icons instead of '\u2600', '\u2601' and '\u2603'.
I added a test script for ordinary unittest module because I inferred from issue #4 that tests would re-write sooner.
